### PR TITLE
add ability to skip resource cleanup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ steps:
       # armTemplateParametersFile: myArmTemplateParameters.json [optional]
       # additionalParameters: 'key1=value key2=value keyN=value' [optional]
       # skipAzModuleInstallation: true [optional]
+      # cleanupResources: true [optional]
 ```
 
 ### Inputs
@@ -64,6 +65,7 @@ steps:
 | `armTemplateParametersFile` | Data Factory ARM template parameters file | false | `ARMTemplateParametersForFactory.json`  |
 | `additionalParameters` | Data Factory custom parameters. Key-values must be splitted by space. | false |
 | `skipAzModuleInstallation` | Skip `Az` powershell module installation. | false | false |
+| `cleanupResources` | Whether or not to run the cleanup step to remove deleted factory elements. | false | true |
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Parameters which skip the Az module installation'
     required: false
     default: 'false'
+  cleanupResources:
+    description: 'Whether or not to run the cleanup step to remove deleted factory elements'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -56,5 +60,6 @@ runs:
           -ResourceGroupName "${{ inputs.resourceGroupName }}" `
           -DataFactoryName '${{ inputs.dataFactoryName }}' `
           -predeployment $false `
+          -cleanupResources ('${{ inputs.cleanupResources }}' -eq 'true') `
           -deleteDeployment $true
       shell: pwsh


### PR DESCRIPTION
This change gives the user the option to skip the cleanup step at the end.

It creates a new parameter `cleanupResources`, which allows the cleanup of deleted resources to be skipped during the post-deployment phase. It defaults to `true`, and is optional to preserve current behavior.

While valuable, I ran into trouble using it because my pipeline names are parameterized in my template. This made it so the post-deployment cleanup phase always wants to delete my new pipelines, because it is doing a naive name comparison, not the "evaluated" name of my pipeline. Which, makes sense, and would be a MUCH harder problem to solve.
