### PR TITLE
add `Microsoft.DataFactory*`  to the list of deployment names to search for when deleting

### DIFF
--- a/PrePostDeploymentScript.ps1
+++ b/PrePostDeploymentScript.ps1
@@ -258,7 +258,7 @@ else {
     if ($deleteDeployment -eq $true) {
         Write-Host "Deleting ARM deployment ... under resource group: " $ResourceGroupName
         $deployments = Get-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName
-        $deploymentsToConsider = $deployments | Where { $_.DeploymentName -like "ArmTemplate_master*" -or $_.DeploymentName -like "ArmTemplateForFactory*" } | Sort-Object -Property Timestamp -Descending
+        $deploymentsToConsider = $deployments | Where { $_.DeploymentName -like "ArmTemplate_master*" -or $_.DeploymentName -like "ArmTemplateForFactory*"  -or $_.DeploymentName -like "Microsoft.DataFactory*" } | Sort-Object -Property Timestamp -Descending
         $deploymentName = $deploymentsToConsider[0].DeploymentName
 
        Write-Host "Deployment to be deleted: " $deploymentName


### PR DESCRIPTION
`Microsoft.DataFactory` appears to be the default deployment name prefix for deployments through `arm-deploy`.

This change adds this to the list of deployment names it searches for when looking for the deployment to delete during post-deployment.